### PR TITLE
ci: add EAS Hosting deploy workflow on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to EAS Hosting
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Deploy web app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Expo & EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Deploy to EAS Hosting
+        run: eas deploy --non-interactive


### PR DESCRIPTION
Triggers eas deploy on every push to main using expo-github-action. Requires EXPO_TOKEN secret set in the GitHub repo settings.